### PR TITLE
Exclude check and jar tasks when building Halo

### DIFF
--- a/halo-next-docker-build/action.yaml
+++ b/halo-next-docker-build/action.yaml
@@ -35,9 +35,7 @@ runs:
     - name: Build with Gradle
       shell: bash
       run: |
-        ./gradlew clean build -x test
-        # we don't need the plain jar when building docker image.
-        rm -rf build/libs/*-plain.jar
+        ./gradlew clean build -x check -x jar
     - name: Docker meta for Halo
       id: meta
       uses: docker/metadata-action@v3


### PR DESCRIPTION
### What this PR does / Why we need it

This PR excludes check and jar tasks while building Halo. Because they are really unnecessary at here.

/kind improvement
/cc @halo-sigs/halo 

```release-note
None
```