### PR TITLE
Set up build environment and build package before building docker image

### DIFF
--- a/admin-next-docker-build-push/action.yaml
+++ b/admin-next-docker-build-push/action.yaml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Environment Set Up
-      uses: halo-sigs/actions/admin-env-setup
+      uses: halo-sigs/actions/admin-env-setup@main
     - name: Build Package
       shell: bash
       run: |

--- a/admin-next-docker-build-push/action.yaml
+++ b/admin-next-docker-build-push/action.yaml
@@ -13,19 +13,19 @@ inputs:
   image-name:
     description: The basic name of docker.
     required: false
-    default: "halo-admin"
-  checkout-from:
-    description: Which ref should be checkouted.
-    required: false
-    default: ${{ github.ref }}
+    default: "admin"
 
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
-      with:
-        ref: ${{ inputs.checkout-from }}
-        submodules: true
+    - name: Environment Set Up
+      uses: halo-sigs/actions/admin-env-setup
+    - name: Build Package
+      shell: bash
+      run: |
+        pnpm install
+        pnpm build:packages
+        pnpm build
     - name: Docker meta for Halo admin
       id: meta
       uses: docker/metadata-action@v3


### PR DESCRIPTION
#### What this PR does

Set up build environment and build package before building docker image.

You can see the result of this change from <https://github.com/JohnNiang/halo-admin/runs/7407775948?check_suite_focus=true#step:3:1>.

/kind improvement

#### Release Note

```release-note
Set up build environment and build package before building docker image
```