### PR TITLE
Remove checkout step while buidling

### DIFF
--- a/halo-next-docker-build/action.yaml
+++ b/halo-next-docker-build/action.yaml
@@ -14,18 +14,10 @@ inputs:
     description: The basic name of docker.
     required: false
     default: "halo"
-  checkout-from:
-    description: Which ref should be checkouted.
-    required: false
-    default: ${{ github.ref }}
 
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
-      with:
-        ref: ${{ inputs.checkout-from }}
-        submodules: true
     - name: Setup JDK 17
       uses: actions/setup-java@v2
       with:


### PR DESCRIPTION
#### What this PR does

Remove checkout step in composite action. Because it's unnecessary at here. Users can add checkout step outside it.

Please check the result of this action at <https://github.com/JohnNiang/halo/runs/7412200598?check_suite_focus=true#step:3:1>.

/kind improvement

```release-note
None
```