### PR TITLE
Make docker image name fixed

### DIFF
--- a/admin-next-docker-build-push/action.yaml
+++ b/admin-next-docker-build-push/action.yaml
@@ -42,7 +42,7 @@ runs:
         then
           echo '::set-output name=docker_image::'
         else
-          echo '::set-output name=docker_image::${{ inputs.dockerhub-user }}/${{ inputs.image-name }}'
+          echo '::set-output name=docker_image::halohub/${{ inputs.image-name }}'
         fi
     - name: Docker meta for Halo admin
       id: meta

--- a/halo-next-docker-build/action.yaml
+++ b/halo-next-docker-build/action.yaml
@@ -43,7 +43,7 @@ runs:
         then
           echo '::set-output name=docker_image::'
         else
-          echo '::set-output name=docker_image::${{ inputs.dockerhub-user }}/${{ inputs.image-name }}'
+          echo '::set-output name=docker_image::halohub/${{ inputs.image-name }}'
         fi
       shell: bash
     - name: Docker meta for Halo


### PR DESCRIPTION
Docker Hub can have multiple organizations, but organization name cannot be used for login, and the login username is not directly related to the actual image name, so we fixed the image name at present. 

In the future, we may provide an input to dynamically set image name.

/kind improvement
/cc @halo-sigs/halo 

```release-note
None
```