### PR TITLE
Build and package Console into Halo before building Halo

### DIFF
--- a/halo-next-docker-build/action.yaml
+++ b/halo-next-docker-build/action.yaml
@@ -26,6 +26,26 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Checkout Console
+      uses: actions/checkout@v2
+      with:
+        repository: halo-dev/console
+        ref: next
+        path: console
+    - name: Console Environment Set Up
+      uses: halo-sigs/actions/admin-env-setup@main
+    - name: Build Console
+      shell: bash
+      working-directory: console
+      run: |
+        pnpm install
+        pnpm build:packages
+        pnpm build
+    - name: Copy Dist into Halo
+      shell: bash
+      run: |
+        mkdir -p src/main/resources/console
+        cp -r console/dist/* src/main/resources/console
     - name: Setup JDK 17
       uses: actions/setup-java@v2
       with:


### PR DESCRIPTION
> I have tested this action in my repository, please refer to https://github.com/JohnNiang/halo/actions/runs/3110295461/jobs/5041445842.

Steps to test:

1. Pull temporary image built in the action above

    ```bash
    docker pull ghcr.io/johnniang/halo-dev:sha-9762904
    ```

2. Run it

    ```bash
    docker run --rm -it -p 8090:8090 ghcr.io/johnniang/halo-dev:sha-9762904
    ```

3. Request console: <http://localhost:8090/console/>

```release-note
None
```

/kind feature
