### PR TITLE
chore: set default node version to 18

### DIFF
--- a/admin-env-setup/action.yaml
+++ b/admin-env-setup/action.yaml
@@ -5,7 +5,7 @@ inputs:
   node-version:
     description: Node.js version.
     required: false
-    default: "16"
+    default: "18"
   pnpm-version:
     description: pnpm version.
     required: false


### PR DESCRIPTION
将默认的 Node 版本改为 18，目前 Node 18 已经是最新的 LTS 版本，参见：https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#18.12.1

```release-note
None
```

/kind improvement