### PR TITLE
Disable tagging latest tag when releasing

### DIFF
--- a/admin-next-docker-build-push/action.yaml
+++ b/admin-next-docker-build-push/action.yaml
@@ -57,6 +57,8 @@ runs:
           type=semver,pattern={{ version }}
           type=semver,pattern={{major}}.{{minor}}
           type=sha,enabled=${{ github.event_name == 'push' }}
+        flavor: |
+          latest=false
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx

--- a/halo-next-docker-build/action.yaml
+++ b/halo-next-docker-build/action.yaml
@@ -91,6 +91,8 @@ runs:
           type=semver,pattern={{ version }}
           type=semver,pattern={{major}}.{{minor}}
           type=sha,enabled=${{ github.event_name == 'push' }}
+        flavor: |
+          latest=false
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx


### PR DESCRIPTION
#### What this PR does?

Add flavor option for docker metadat action to disable tagging latest tag on image.

![image](https://user-images.githubusercontent.com/16865714/204956738-fc760158-c337-4901-8e3c-ec7725bbed8b.png)

```release-note
None
```

/kind improvement