### PR TITLE
Add more platforms for building docker image

### DIFF
--- a/halo-next-docker-build/action.yaml
+++ b/halo-next-docker-build/action.yaml
@@ -115,7 +115,7 @@ runs:
       with:
         context: .
         file: ./Dockerfile
-        platforms: linux/amd64,linux/arm/v7,linux/arm64
+        platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
         labels: ${{ steps.meta.outputs.labels }}
         tags: ${{ steps.meta.outputs.tags }}
         push: ${{ (inputs.ghcr-token != '' || inputs.dockerhub-token != '') && inputs.push == 'true' }}


### PR DESCRIPTION
/kind feature

Docker build of Halo is based on [eclipse-temurin:17-jre](https://github.com/halo-dev/halo/blob/cd5cc747147aadcf367dcefb3b5332ccaa6bf8a5/Dockerfile#L9), which is support multi-arch Linux platforms `linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x`. So we can support these platforms as well.

![image](https://user-images.githubusercontent.com/16865714/206339074-96c59508-dece-468d-a7ab-0891ade56c20.png)

```release-note
添加 Docker 镜像多架构支持：linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
```