### PR TITLE
Refactor the halo build process

### DIFF
--- a/halo-next-docker-build/action.yaml
+++ b/halo-next-docker-build/action.yaml
@@ -41,7 +41,7 @@ runs:
     - name: Build Console
       shell: bash
       run: |
-        make cbuild
+        make -C console build
     - name: Reset version of Halo
       if: github.event_name == 'release'
       shell: bash

--- a/halo-next-docker-build/action.yaml
+++ b/halo-next-docker-build/action.yaml
@@ -30,32 +30,18 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout Console
-      uses: actions/checkout@v3
-      with:
-        repository: halo-dev/console
-        ref: ${{ inputs.console-ref }}
-        path: console
-    - name: Console Environment Set Up
-      uses: halo-sigs/actions/admin-env-setup@main
-    - name: Build Console
-      shell: bash
-      working-directory: console
-      run: |
-        pnpm install
-        pnpm build:packages
-        pnpm build
-    - name: Copy Dist into Halo
-      shell: bash
-      run: |
-        mkdir -p src/main/resources/console
-        cp -r console/dist/* src/main/resources/console
-    - name: Setup JDK 17
+    - name: Setup JDK
       uses: actions/setup-java@v3
       with:
         distribution: "temurin"
         cache: "gradle"
         java-version: 17
+    - name: Setup console environment
+      uses: halo-sigs/actions/admin-env-setup@main
+    - name: Build Console
+      shell: bash
+      run: |
+        make cbuild
     - name: Reset version of Halo
       if: github.event_name == 'release'
       shell: bash


### PR DESCRIPTION
We have a plan to move console repo into halo repo, please see:

- https://github.com/halo-dev/halo/issues/3393
- https://github.com/halo-dev/halo/pull/3433

This PR mainly adapt the halo build process due to the movement above.

/kind cleanup
/hold

Hold this PR until https://github.com/halo-dev/halo/pull/3433 merged.

Currently, we can use action named `JohnNiang/actions/halo-next-docker-build@refactor/halo-build` to test.

```release-note
None
```